### PR TITLE
북마크 리스트 구현중

### DIFF
--- a/coz-shopping/src/Components/Bookmark.css
+++ b/coz-shopping/src/Components/Bookmark.css
@@ -1,11 +1,11 @@
-.itemlist_container {
+
+.bookmarklist_container {
     padding: 24px;
     display: flex;
     flex-direction: column;
     gap: 24px;
 }
-
-.item_container {
+.bookmark_container {
     display: flex;
     flex-direction: row;
     gap: 24px;
@@ -16,3 +16,4 @@ h2 {
     font-size: 24px;
     font-weight: 600;
 }
+

--- a/coz-shopping/src/Components/Bookmark.css
+++ b/coz-shopping/src/Components/Bookmark.css
@@ -1,5 +1,6 @@
 
 .bookmarklist_container {
+    flex: 1 0 332.5px;
     padding: 24px;
     display: flex;
     flex-direction: column;
@@ -15,5 +16,6 @@ h2 {
     margin: 0;
     font-size: 24px;
     font-weight: 600;
+    
 }
 

--- a/coz-shopping/src/Components/Bookmark.css
+++ b/coz-shopping/src/Components/Bookmark.css
@@ -5,7 +5,7 @@
     flex-direction: column;
     gap: 24px;
 }
-.bookmark_container {
+.bookmark_container{
     display: flex;
     flex-direction: row;
     gap: 24px;

--- a/coz-shopping/src/Components/Bookmark.js
+++ b/coz-shopping/src/Components/Bookmark.js
@@ -22,7 +22,7 @@ const BookmarkList = ({bookmarkList, setBookmarkList}) => {
         setViewlist(view);
         }
     },[bookmarkList])
-    console.log(viewList)
+    
     return (
         <div className="bookmarklist_container">
             <h2>북마크 리스트</h2>

--- a/coz-shopping/src/Components/Bookmark.js
+++ b/coz-shopping/src/Components/Bookmark.js
@@ -1,15 +1,44 @@
-import React from "react";
+import React ,{useState, useEffect} from "react";
+import ProductItem from "./Productitem";
+import CategoryItem from "./CategoryItem";
+import ExhibitionItem from "./ExhibitionItem";
+import BrandItem from "./BrandItem";
+import "./Bookmark.css"
 
-const BookmarkList = ({setBookmarkList}) => {
-    const product = JSON.parse(window.localStorage.getItem('ProductBookmark'))
+const BookmarkList = ({bookmarkList, setBookmarkList}) => {
     
-    setBookmarkList()
-
+   //타입별로 나누지말고 북마크 속성을 true로 할당해서 products에 저장
+    const [viewList,setViewlist] = useState([]);
+   
+    useEffect(()=> {
+        if(bookmarkList !== undefined ){
+            const view = [];
+            for(let i=0; i<bookmarkList.length; i++){
+                view.push(bookmarkList[i]);
+                if(i===3){
+                    break;
+                }
+            }
+        setViewlist(view);
+        }
+    },[bookmarkList])
+    console.log(viewList)
     return (
         <div className="bookmarklist_container">
             <h2>북마크 리스트</h2>
             <div className="bookmark_container">
-
+                {viewList.map((el) => {
+                    if(el.type === 'Product') {
+                        return <ProductItem data={[el]} idx={0} key={el.id} setBookmarkList={setBookmarkList} bookmarkList={bookmarkList} />
+                    } else if(el.type === "Category"){
+                        return <CategoryItem data={[el]} idx={0} key={el.id} setBookmarkList={setBookmarkList} bookmarkList={bookmarkList}/>
+                    } else if(el.type ==="Exhibition"){
+                        return <ExhibitionItem data={[el]} idx={0} key={el.id} setBookmarkList={setBookmarkList} bookmarkList={bookmarkList}/>
+                    } else if(el.type ==="Brand"){
+                        return <BrandItem data={[el]} idx={0} key={el.id} setBookmarkList={setBookmarkList} bookmarkList={bookmarkList}/>
+                    }
+                })
+                }
             </div>
         </div>
     )

--- a/coz-shopping/src/Components/Bookmark.js
+++ b/coz-shopping/src/Components/Bookmark.js
@@ -1,0 +1,18 @@
+import React from "react";
+
+const BookmarkList = ({setBookmarkList}) => {
+    const product = JSON.parse(window.localStorage.getItem('ProductBookmark'))
+    
+    setBookmarkList()
+
+    return (
+        <div className="bookmarklist_container">
+            <h2>북마크 리스트</h2>
+            <div className="bookmark_container">
+
+            </div>
+        </div>
+    )
+}
+
+export default BookmarkList

--- a/coz-shopping/src/Components/BrandItem.js
+++ b/coz-shopping/src/Components/BrandItem.js
@@ -1,10 +1,9 @@
-import React ,{useState, useEffect} from "react";
+import React ,{useState} from "react";
 import "./item.css"
 import Modal from "./Modal";
 
-const BrandItem = ({data, idx}) => {
+const BrandItem = ({data, idx, setBookmarkList, bookmarkList}) => {
     const [clicked, setClicked] = useState(false);
-    const [list, setList] = useState([]);
     const [open, setOpen] = useState(false);
 
     const handleModal = () => {
@@ -12,28 +11,20 @@ const BrandItem = ({data, idx}) => {
     }
 
     const handleBookmark = () => {
-        setList([...list, data[idx]]);
+        setBookmarkList([...bookmarkList, data[idx]])
         setClicked(!clicked);
     }
     const deleteBookmark = () => {
-        setList([...list.filter((el)=> el!==data[idx])]);
+        setBookmarkList([...bookmarkList.filter((el)=> el!==data[idx])]);
         setClicked(!clicked);
     }
 
-    const setBookmarkList = () => {
-        window.localStorage.setItem('BrandBookmark', JSON.stringify(list));
-        console.log(JSON.parse(window.localStorage.getItem('BrandBookmark')))
-    }
-    useEffect(() => {
-        setBookmarkList();
-    }, [list]);
-
     if(data.length === 0){
         return 
-    } else {
+    } 
     return (
         <section>
-            {open ? <Modal data={data[idx]} setOpen={setOpen} setClicked={setClicked} setList={setList} list={list} clicked={clicked}/> : null}
+            {open ? <Modal data={data[idx]} setOpen={setOpen} setClicked={setClicked} setList={setBookmarkList} list={bookmarkList} clicked={clicked}/> : null}
             <div className="img_container">
                 <img src={data[idx].brand_image_url} alt='' className="background" onClick={handleModal}></img>
                 <img src="img/북마크 해제 아이콘.png" className={!clicked ? "bookmark" : 'hide'} onClick={handleBookmark}></img>
@@ -50,7 +41,7 @@ const BrandItem = ({data, idx}) => {
             </div>
         </section>
         )
-    }
+    
 }
 
 export default BrandItem

--- a/coz-shopping/src/Components/BrandItem.js
+++ b/coz-shopping/src/Components/BrandItem.js
@@ -19,11 +19,15 @@ const BrandItem = ({data, idx, setBookmarkList, bookmarkList}) => {
         setClicked(!clicked);
     }
     useEffect(()=>{
+        if(data[idx] === undefined){
+            return
+        }
         if(bookmarkList.filter((el)=>el.id===data[idx].id).length !== 0){
             setClicked(true);
         } else {
             setClicked(false);
         }
+        window.localStorage.setItem('bookmarkList', JSON.stringify(bookmarkList));
     },[bookmarkList])
 
     if(data.length === 0){

--- a/coz-shopping/src/Components/BrandItem.js
+++ b/coz-shopping/src/Components/BrandItem.js
@@ -1,4 +1,4 @@
-import React ,{useState} from "react";
+import React ,{useState, useEffect} from "react";
 import "./item.css"
 import Modal from "./Modal";
 
@@ -18,6 +18,13 @@ const BrandItem = ({data, idx, setBookmarkList, bookmarkList}) => {
         setBookmarkList([...bookmarkList.filter((el)=> el!==data[idx])]);
         setClicked(!clicked);
     }
+    useEffect(()=>{
+        if(bookmarkList.filter((el)=>el.id===data[idx].id).length !== 0){
+            setClicked(true);
+        } else {
+            setClicked(false);
+        }
+    },[bookmarkList])
 
     if(data.length === 0){
         return 

--- a/coz-shopping/src/Components/CategoryItem.js
+++ b/coz-shopping/src/Components/CategoryItem.js
@@ -1,4 +1,4 @@
-import React ,{useState} from "react";
+import React ,{useState, useEffect} from "react";
 import "./item.css"
 import Modal from "./Modal";
 
@@ -18,6 +18,13 @@ const CategoryItem = ({data, idx, setBookmarkList, bookmarkList}) => {
         setBookmarkList([...bookmarkList.filter((el)=> el!==data[idx])]);
         setClicked(!clicked);
     }
+    useEffect(()=>{
+        if(bookmarkList.filter((el)=>el.id===data[idx].id).length !== 0){
+            setClicked(true);
+        } else {
+            setClicked(false);
+        }
+    },[bookmarkList])
 
     if(data.length === 0){
         return 

--- a/coz-shopping/src/Components/CategoryItem.js
+++ b/coz-shopping/src/Components/CategoryItem.js
@@ -1,10 +1,9 @@
-import React ,{useState, useEffect} from "react";
+import React ,{useState} from "react";
 import "./item.css"
 import Modal from "./Modal";
 
-const CategoryItem = ({data, idx}) => {
+const CategoryItem = ({data, idx, setBookmarkList, bookmarkList}) => {
     const [clicked, setClicked] = useState(false);
-    const [list, setList] = useState([]);
     const [open, setOpen] = useState(false);
 
     const handleModal = () => {
@@ -12,29 +11,20 @@ const CategoryItem = ({data, idx}) => {
     }
 
     const handleBookmark = () => {
-        setList([...list, data[idx]]);
+        setBookmarkList([...bookmarkList, data[idx]])
         setClicked(!clicked);
     }
     const deleteBookmark = () => {
-        setList([...list.filter((el)=> el!==data[idx])]);
+        setBookmarkList([...bookmarkList.filter((el)=> el!==data[idx])]);
         setClicked(!clicked);
     }
 
-    const setBookmarkList = () => {
-        window.localStorage.setItem('CategoryBookmark', JSON.stringify(list));
-        console.log(JSON.parse(window.localStorage.getItem('CategoryBookmark')))
-    }
-    useEffect(() => {
-        setBookmarkList();
-    }, [list]);
-
     if(data.length === 0){
         return 
-    } else {
-
+    } 
     return (
         <section>
-            {open ? <Modal data={data[idx]} setOpen={setOpen} setClicked={setClicked} setList={setList} list={list} clicked={clicked}/> : null}
+            {open ? <Modal data={data[idx]} setOpen={setOpen} setClicked={setClicked} setList={setBookmarkList} list={bookmarkList} clicked={clicked}/> : null}
             <div className="img_container">
                 <img src={data[idx].image_url} alt='' className="background" onClick={handleModal}></img>
                 <img src="img/북마크 해제 아이콘.png" className={!clicked ? "bookmark" : 'hide'} onClick={handleBookmark}></img>
@@ -45,7 +35,7 @@ const CategoryItem = ({data, idx}) => {
             </div>
         </section>
         )
-    }
+    
 }
 
 export default CategoryItem

--- a/coz-shopping/src/Components/CategoryItem.js
+++ b/coz-shopping/src/Components/CategoryItem.js
@@ -19,11 +19,15 @@ const CategoryItem = ({data, idx, setBookmarkList, bookmarkList}) => {
         setClicked(!clicked);
     }
     useEffect(()=>{
+        if(data[idx] === undefined){
+            return
+        }
         if(bookmarkList.filter((el)=>el.id===data[idx].id).length !== 0){
             setClicked(true);
         } else {
             setClicked(false);
         }
+        window.localStorage.setItem('bookmarkList', JSON.stringify(bookmarkList));
     },[bookmarkList])
 
     if(data.length === 0){

--- a/coz-shopping/src/Components/ExhibitionItem.js
+++ b/coz-shopping/src/Components/ExhibitionItem.js
@@ -19,11 +19,15 @@ const ExhibitionItem = ({data, idx, setBookmarkList, bookmarkList}) => {
         setClicked(!clicked);
     }
     useEffect(()=>{
+        if(data[idx] === undefined){
+            return
+        }
         if(bookmarkList.filter((el)=>el.id===data[idx].id).length !== 0){
             setClicked(true);
         } else {
             setClicked(false);
         }
+        window.localStorage.setItem('bookmarkList', JSON.stringify(bookmarkList));
     },[bookmarkList])
 
     if(data.length === 0){

--- a/coz-shopping/src/Components/ExhibitionItem.js
+++ b/coz-shopping/src/Components/ExhibitionItem.js
@@ -1,4 +1,4 @@
-import React ,{useState} from "react";
+import React ,{useState, useEffect} from "react";
 import "./item.css"
 import Modal from "./Modal";
 
@@ -18,6 +18,13 @@ const ExhibitionItem = ({data, idx, setBookmarkList, bookmarkList}) => {
         setBookmarkList([...bookmarkList.filter((el)=> el!==data[idx])]);
         setClicked(!clicked);
     }
+    useEffect(()=>{
+        if(bookmarkList.filter((el)=>el.id===data[idx].id).length !== 0){
+            setClicked(true);
+        } else {
+            setClicked(false);
+        }
+    },[bookmarkList])
 
     if(data.length === 0){
         return 

--- a/coz-shopping/src/Components/ExhibitionItem.js
+++ b/coz-shopping/src/Components/ExhibitionItem.js
@@ -1,10 +1,9 @@
-import React ,{useState, useEffect} from "react";
+import React ,{useState} from "react";
 import "./item.css"
 import Modal from "./Modal";
 
-const ExhibitionItem = ({data, idx}) => {
+const ExhibitionItem = ({data, idx, setBookmarkList, bookmarkList}) => {
     const [clicked, setClicked] = useState(false);
-    const [list, setList] = useState([]);
     const [open, setOpen] = useState(false);
 
     const handleModal = () => {
@@ -12,28 +11,20 @@ const ExhibitionItem = ({data, idx}) => {
     }
 
     const handleBookmark = () => {
-        setList([...list, data[idx]]);
+        setBookmarkList([...bookmarkList, data[idx]])
         setClicked(!clicked);
     }
     const deleteBookmark = () => {
-        setList([...list.filter((el)=> el!==data[idx])]);
+        setBookmarkList([...bookmarkList.filter((el)=> el!==data[idx])]);
         setClicked(!clicked);
     }
 
-    const setBookmarkList = () => {
-        window.localStorage.setItem('ExhibitionBookmark', JSON.stringify(list));
-        console.log(JSON.parse(window.localStorage.getItem('ExhibitionBookmark')))
-    }
-    useEffect(() => {
-        setBookmarkList();
-    }, [list]);
-
     if(data.length === 0){
         return 
-    } else {
+    } 
     return (
         <section>
-            {open ? <Modal data={data[idx]} setOpen={setOpen} setClicked={setClicked} setList={setList} list={list} clicked={clicked}/> : null}
+            {open ? <Modal data={data[idx]} setOpen={setOpen} setClicked={setClicked} setList={setBookmarkList} list={bookmarkList} clicked={clicked}/> : null}
             <div className="img_container">
                 <img src={data[idx].image_url} alt='' className="background" onClick={handleModal}></img>
                 <img src="img/북마크 해제 아이콘.png" className={!clicked ? "bookmark" : 'hide'} onClick={handleBookmark}></img>
@@ -49,7 +40,6 @@ const ExhibitionItem = ({data, idx}) => {
             </div>
         </section>
         )
-    }
 }
 
 export default ExhibitionItem

--- a/coz-shopping/src/Components/Header.css
+++ b/coz-shopping/src/Components/Header.css
@@ -48,7 +48,9 @@ h1:hover {
         visibility: visible;
         display: flex;
         flex-direction: column;
+        align-items: stretch;
         justify-content: center;
+        text-align: left;
         position: absolute;
         top: 100px;
         left: 10;
@@ -69,6 +71,7 @@ h1:hover {
 
 .dropdown_menu {
     border: 1px solid rgba(0,0,0,0.1);
+    padding: 10px;
 }
 
 label:hover {

--- a/coz-shopping/src/Components/Header.css
+++ b/coz-shopping/src/Components/Header.css
@@ -1,5 +1,6 @@
 header {
     height: 80px;
+    width: 100vw;
     display: flex;
     align-items: center;
     justify-content: center;

--- a/coz-shopping/src/Components/Header.js
+++ b/coz-shopping/src/Components/Header.js
@@ -16,7 +16,7 @@ const Header = ( ) => {
             <section className="right_section" >
                 <img src="img/아이콘.png" className="hamburger" alt="더보기" ></img>
                 <div className="dropdown_container">  
-                    <div className="dropdown_menu">000님, 안녕하세요!</div>
+                    <div className="dropdown_menu"> 허찬욱님, 안녕하세요!</div>
                     <div className="dropdown_menu">
                         <Link to='/products/list'>
                             <img src="img/상품 아이콘.png" alt="상품리스트 페이지" id="product_icon"></img>

--- a/coz-shopping/src/Components/ItemList.js
+++ b/coz-shopping/src/Components/ItemList.js
@@ -25,10 +25,13 @@ const ItemList = ({data}) => {
     
     return (
         <div className="itemlist_container">
-            <ProductItem data={Product} idx={productidx} />
-            <CategoryItem data={Category} idx={categoryidx} />
-            <ExhibitionItem data={Exhibition} idx={exhibitionidx} />
-            <BrandItem data={Brand} idx={brandidx} />
+            <h2>상품 리스트</h2>
+            <div className="item_container">
+                <ProductItem data={Product} idx={productidx} />
+                <CategoryItem data={Category} idx={categoryidx} />
+                <ExhibitionItem data={Exhibition} idx={exhibitionidx} />
+                <BrandItem data={Brand} idx={brandidx} />
+            </div>
         </div>
     )
 }

--- a/coz-shopping/src/Components/ItemList.js
+++ b/coz-shopping/src/Components/ItemList.js
@@ -1,36 +1,48 @@
-import React from "react";
+import React , {useEffect} from "react";
 import ProductItem from "./Productitem";
 import CategoryItem from "./CategoryItem";
 import ExhibitionItem from "./ExhibitionItem";
 import BrandItem from "./BrandItem";
 import "./ItemList.css"
  
-const ItemList = ({data}) => {
-
-    const Product = data.filter((item)=>item.type === 'Product')
-    const Category = data.filter((item)=>item.type === 'Category')
-    const Exhibition = data.filter((item)=>item.type === 'Exhibition')
-    const Brand = data.filter((item)=>item.type === 'Brand')
+const ItemList = ({data, setBookmarkList, bookmarkList}) => {
+    const Item = (type) => {
+        return data.filter((item)=>item.type === type)
+    }
+    const Product = Item('Product')
+    const Category = Item('Category')
+    const Exhibition = Item('Exhibition')
+    const Brand = Item('Brand')
 
     const getRandomIntInclusive = (min,max) => {
         min = Math.ceil(min);
         max = Math.floor(max);
         return Math.floor(Math.random()*(max-min+1))+min;
     }
+    let productidx = 0;  
+    let categoryidx = 0; 
+    let exhibitionidx = 0;
+    let brandidx = 0;
 
-    const productidx = data.length === 0 ? 0 : getRandomIntInclusive(0, Product.length-1)
-    const categoryidx = data.length === 0 ? 0 : getRandomIntInclusive(0, Category.length-1)
-    const exhibitionidx = data.length === 0 ? 0 : getRandomIntInclusive(0, Exhibition.length-1)
-    const brandidx = data.length === 0 ? 0 : getRandomIntInclusive(0, Brand.length-1)
+    const setRandomIdx = ()=> {
+        productidx = getRandomIntInclusive(0, Product.length-1)
+        categoryidx = getRandomIntInclusive(0, Category.length-1)
+        exhibitionidx = getRandomIntInclusive(0, Exhibition.length-1)
+        brandidx = getRandomIntInclusive(0, Brand.length-1)
+    }
     
+    useEffect(()=> {
+        setRandomIdx();
+    },[data])
+
     return (
         <div className="itemlist_container">
             <h2>상품 리스트</h2>
             <div className="item_container">
-                <ProductItem data={Product} idx={productidx} />
-                <CategoryItem data={Category} idx={categoryidx} />
-                <ExhibitionItem data={Exhibition} idx={exhibitionidx} />
-                <BrandItem data={Brand} idx={brandidx} />
+                <ProductItem data={Product} idx={productidx} setBookmarkList={setBookmarkList} bookmarkList={bookmarkList} />
+                <CategoryItem data={Category} idx={categoryidx} setBookmarkList={setBookmarkList} bookmarkList={bookmarkList}/>
+                <ExhibitionItem data={Exhibition} idx={exhibitionidx} setBookmarkList={setBookmarkList} bookmarkList={bookmarkList}/>
+                <BrandItem data={Brand} idx={brandidx} setBookmarkList={setBookmarkList} bookmarkList={bookmarkList}/>
             </div>
         </div>
     )

--- a/coz-shopping/src/Components/Modal.js
+++ b/coz-shopping/src/Components/Modal.js
@@ -12,12 +12,16 @@ const Modal = ({data, setOpen, setClicked, setList,list, clicked}) => {
         setClicked(!clicked);
     }
     let title, url
-    if(data.type !== 'Brand'){
-        title = data.title;
-        url = data.image_url;
-    } else {
+    if(data.type == 'Brand'){
         title = data.brand_name;
         url = data.brand_image_url;
+    } else if(data.type === 'Category'){
+        title = `# ${data.title}`;
+        url = data.image_url;
+    }
+    else {
+        title = data.title;
+        url = data.image_url;
     }
 
     return (

--- a/coz-shopping/src/Components/Modal.js
+++ b/coz-shopping/src/Components/Modal.js
@@ -12,7 +12,7 @@ const Modal = ({data, setOpen, setClicked, setList,list, clicked}) => {
         setClicked(!clicked);
     }
     let title, url
-    if(data.type == 'Brand'){
+    if(data.type ==='Brand'){
         title = data.brand_name;
         url = data.brand_image_url;
     } else if(data.type === 'Category'){

--- a/coz-shopping/src/Components/Productitem.js
+++ b/coz-shopping/src/Components/Productitem.js
@@ -6,6 +6,9 @@ const ProductItem = ({data, idx, setBookmarkList, bookmarkList}) => {
     const [clicked, setClicked] = useState(false);
     const [open, setOpen] = useState(false);
 
+    const localBookmarkList = JSON.parse(window.localStorage.getItem('bookmarkList'))
+    
+    console.log('data[idx]:', data[idx], 'localBookmarkList:', localBookmarkList)
     const handleModal = () => {
         setOpen(!open);
     }
@@ -18,13 +21,17 @@ const ProductItem = ({data, idx, setBookmarkList, bookmarkList}) => {
         setBookmarkList([...bookmarkList.filter((el)=> el!==data[idx])]);
         setClicked(!clicked);
     }
+    
     useEffect(()=>{
-        if(bookmarkList.filter((el)=>el.id===data[idx].id).length !== 0){
+        if(data[idx] === undefined){
+            return
+        }
+        if(bookmarkList.filter((el)=>el.id === data[idx].id).length !== 0){
             setClicked(true);
         } else {
             setClicked(false);
         }
-        
+        window.localStorage.setItem('bookmarkList', JSON.stringify(bookmarkList));
     },[bookmarkList])
 
     if(data.length === 0){

--- a/coz-shopping/src/Components/Productitem.js
+++ b/coz-shopping/src/Components/Productitem.js
@@ -1,10 +1,9 @@
-import React, {useState, useEffect} from "react";
+import React, {useState} from "react";
 import './item.css'
 import Modal from "./Modal";
 
-const ProductItem = ({data, idx}) => {
+const ProductItem = ({data, idx, setBookmarkList, bookmarkList}) => {
     const [clicked, setClicked] = useState(false);
-    const [list, setList] = useState([]);
     const [open, setOpen] = useState(false);
 
     const handleModal = () => {
@@ -12,28 +11,21 @@ const ProductItem = ({data, idx}) => {
     }
 
     const handleBookmark = () => {
-        setList([...list, data[idx]]);
+        setBookmarkList([...bookmarkList, data[idx]])
         setClicked(!clicked);
     }
     const deleteBookmark = () => {
-        setList([...list.filter((el)=> el!==data[idx])]);
+        setBookmarkList([...bookmarkList.filter((el)=> el!==data[idx])]);
         setClicked(!clicked);
     }
 
-    const setBookmarkList = () => {
-        window.localStorage.setItem('ProductBookmark', JSON.stringify( list));
-        console.log(JSON.parse(window.localStorage.getItem('ProductBookmark')))
-    }
-    useEffect(() => {
-        setBookmarkList();
-    }, [list]);
 
     if(data.length === 0){
         return 
     } else {
     return (
         <section>
-            {open ? <Modal data={data[idx]} setOpen={setOpen} setClicked={setClicked} setList={setList} list={list} clicked={clicked}/> : null}
+            {open ? <Modal data={data[idx]} setOpen={setOpen} setClicked={setClicked} setList={setBookmarkList} list={bookmarkList} clicked={clicked}/> : null}
             <div>
                 <div className="img_container">
                     <img src={data[idx].image_url} alt='' className="background" onClick={handleModal}></img>

--- a/coz-shopping/src/Components/Productitem.js
+++ b/coz-shopping/src/Components/Productitem.js
@@ -1,4 +1,4 @@
-import React, {useState} from "react";
+import React, {useState, useEffect} from "react";
 import './item.css'
 import Modal from "./Modal";
 
@@ -18,7 +18,14 @@ const ProductItem = ({data, idx, setBookmarkList, bookmarkList}) => {
         setBookmarkList([...bookmarkList.filter((el)=> el!==data[idx])]);
         setClicked(!clicked);
     }
-
+    useEffect(()=>{
+        if(bookmarkList.filter((el)=>el.id===data[idx].id).length !== 0){
+            setClicked(true);
+        } else {
+            setClicked(false);
+        }
+        
+    },[bookmarkList])
 
     if(data.length === 0){
         return 

--- a/coz-shopping/src/Pages/Main_page.css
+++ b/coz-shopping/src/Pages/Main_page.css
@@ -1,7 +1,9 @@
 .main {
-    padding-top: 104px;
+    padding-top: 80px;
+    width: 100%;
+    gap: 24px;
     display: flex;
     flex-direction: column;
-    justify-content: center;
     align-items: center;
+    justify-content: center;
 }

--- a/coz-shopping/src/Pages/Main_page.js
+++ b/coz-shopping/src/Pages/Main_page.js
@@ -9,6 +9,7 @@ import "./Main_page.css"
 const Main_page = () => {
     const [bookmarkList, setBookmarkList] = useState([]);
     const [data,setData] = useState([]);
+    
     const getData = () => {
         return axios
         .get('http://cozshopping.codestates-seb.link/api/v1/products')
@@ -24,13 +25,12 @@ const Main_page = () => {
         getData();
     }, []);
     const localdata = JSON.parse(window.localStorage.getItem('itemdata'))
-    console.log(data[0])
 
     return (
         <div className="main">
             <Header/>
-            <ItemList data ={data} />
-            <BookmarkList setBookmarkList={setBookmarkList}/>
+            <ItemList data ={data} setBookmarkList={setBookmarkList} bookmarkList={bookmarkList}/>
+            <BookmarkList bookmarkList={bookmarkList} setBookmarkList={setBookmarkList}/>
             <Footer/>
         </div>
     )

--- a/coz-shopping/src/Pages/Main_page.js
+++ b/coz-shopping/src/Pages/Main_page.js
@@ -7,7 +7,8 @@ import axios from 'axios';
 import "./Main_page.css"
 
 const Main_page = () => {
-    const [bookmarkList, setBookmarkList] = useState([]);
+    const localBookmarkList = JSON.parse(window.localStorage.getItem('bookmarkList'))
+    const [bookmarkList, setBookmarkList] = useState(localBookmarkList? localBookmarkList : []);
     const [data,setData] = useState([]);
     
     const getData = () => {

--- a/coz-shopping/src/Pages/Main_page.js
+++ b/coz-shopping/src/Pages/Main_page.js
@@ -2,6 +2,7 @@ import React, {useEffect, useState} from "react";
 import Header from '../Components/Header'
 import Footer from "../Components/Footer";
 import ItemList from "../Components/ItemList";
+import BookmarkList from "../Components/Bookmark"; 
 import axios from 'axios';
 import "./Main_page.css"
 
@@ -29,6 +30,7 @@ const Main_page = () => {
         <div className="main">
             <Header/>
             <ItemList data ={data} />
+            <BookmarkList setBookmarkList={setBookmarkList}/>
             <Footer/>
         </div>
     )


### PR DESCRIPTION
어디까지 구현했는지
현재 아이템 컴포넌트 ui를 완성
북마크 버튼을 누르면 북마크된 별로 북마크버튼 이미지가 바뀌고, 그상태에서 한번 더 누르면 북마크 취소
북마크 버튼을 눌렀을때 각 아이템컴포넌트 타입별로 로컬스토리지에 배열 각 객체를 저장

현재 어딜 구현하고 있는지
메인페이지의 북마크 리스트 섹션

앞으로 어딜 구현할 것인지
북마크리스트 섹션에서 북마크 목록을 받아서 타입별로 아이템컴포넌트를 적용해 띄우기

집중적으로 코드 리뷰를 받고 싶거나 궁금한 부분
현재 구현해둔 아이템컴포넌트의 구현방식이 이상하지는 않은지,
첫 렌더링시에 서버로부터 데이터를 불러오기전에 전달할 프롭스에서 오류가 생겨서 if문으로 분기해 데이터가 생기면 렌더링하게 구현해두었는데 이래도 괜찮은지
프롭스로 인해 북마크 리스트를  저장하는 프롭스를 빼버리고 로컬에 저장하는거 까지만 진행시켜뒀는데 그래도 괜찮은지
북마크 버튼이 눌릴때마다 타입별 로컬스토리지에 저장되는데 이때마다 북마크 리스트만 리렌더링되면서 북마크리스트에 저장하는 방법이 뭘지